### PR TITLE
[dc][GG-002] Add branch and commit convention checks workflow and pre…

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Validate branch name
+BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
+if [[ ! $BRANCH_NAME =~ ^(main|ft/|tt/|rf/|cr/|wr/|fx/|hf/|dc/|ts|ch/) ]]; then
+  echo "Invalid branch name: $BRANCH_NAME"
+  exit 1
+fi
+
+# Validate latest commit message
+COMMIT_MSG=$(git log --pretty=format:%s -1)
+if [[ ! $COMMIT_MSG =~ ^\[(ft|tt|rf|cr|wr|fx|hf|dc|ts|ch)\]\[GG-[0-9]{3}\]\ .+ ]]; then
+  echo "Invalid commit message: $COMMIT_MSG"
+  exit 1
+fi

--- a/.github/workflows/convention_checks.yml
+++ b/.github/workflows/convention_checks.yml
@@ -1,0 +1,27 @@
+name: Convention Checks
+
+on:
+  push:
+    branches:
+      - "**"
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Validate branch name
+        run: |
+          BRANCH_NAME="${GITHUB_REF#refs/heads/}"
+          if [[ ! $BRANCH_NAME =~ ^(main|ft/|tt/|rf/|cr/|wr/|fx/|hf/|dc/|ts/|ch/) ]]; then
+            echo "Invalid branch name: $BRANCH_NAME"
+            exit 1
+          fi
+      - name: Validate commit message
+        run: |
+          COMMIT_MSG=$(git log --pretty=format:%s -1)
+          if [[ ! $COMMIT_MSG =~ ^\[(ft|tt|rf|cr|wr|fx|hf|dc|ts|ch)\]\[GG-[0-9]{3}\]\ .+ ]]; then
+            echo "Invalid commit message: $COMMIT_MSG"
+            exit 1
+          fi


### PR DESCRIPTION
This pull request introduces automated checks to enforce branch naming and commit message conventions both locally and in CI. It adds a pre-push Git hook for local validation and a GitHub Actions workflow to ensure compliance on all pushes.

**Branch and commit message convention enforcement:**

* Added `.githooks/pre-push` script to validate branch names and commit messages before allowing pushes locally. The script checks that branch names start with approved prefixes and commit messages follow the required format.
* Introduced `.github/workflows/convention_checks.yml` GitHub Actions workflow to perform the same validations on every push, ensuring that all contributions meet naming and message standards in CI.…-push hook