### PR TITLE
feat: [tt][GG-020] Add navigation manager and update module definitions

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,10 +3,10 @@ import 'package:feature_commons/module_definition/module_manager.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
 
 import 'firebase_options.dart';
 import 'module_definition/app_module_definition.dart';
+import 'navigation/app_navigation_provider.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -17,17 +17,20 @@ void main() async {
 class MyApp extends ConsumerWidget {
   const MyApp({super.key});
 
+  //TODO: enhance this approach to create the module manager
   static ModuleManager createModuleManager() {
     return ModuleManager()
-      ..registerModule(AuthModuleDefinition())
-      ..registerModule(AppModuleDefinition());
+      ..registerModule(AppModuleDefinition())
+      ..registerModule(AuthModuleDefinition());
   }
 
   //Todo create a GoRouter provider whatch go router video
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final router = GoRouter(routes: []);
+    //TODO: improve this approach
+    final moduleManager = createModuleManager();
+    final router = ref.watch(appRouterProvider(moduleManager));
 
     return MaterialApp.router(
       title: 'GoldenGate App',

--- a/lib/module_definition/app_module_definition.dart
+++ b/lib/module_definition/app_module_definition.dart
@@ -3,6 +3,7 @@ import 'package:go_router/go_router.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../navigation/app_navigation.dart';
+import '../navigation/app_routes.dart';
 
 class AppModuleDefinition extends Module<Ref> {
   static String moduleName = 'AppModuleDefinition';
@@ -17,5 +18,10 @@ class AppModuleDefinition extends Module<Ref> {
   @override
   List<GoRoute> getRouterConfig(Ref ref) {
     return ref.read(appRouteProvider);
+  }
+
+  @override
+  String? initialLocation() {
+    return AppRoutes.initialLocation;
   }
 }

--- a/lib/navigation/app_navigation_provider.dart
+++ b/lib/navigation/app_navigation_provider.dart
@@ -1,0 +1,29 @@
+import 'package:feature_commons/module_definition/module_manager.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:go_router/go_router.dart';
+
+import '../ui/error_pages/page_not_found.dart';
+import '../module_definition/app_module_definition.dart';
+
+part 'app_navigation_provider.g.dart';
+
+@riverpod
+GoRouter appRouter(Ref ref, ModuleManager moduleManager) {
+  return GoRouter(
+    debugLogDiagnostics: true,
+    initialLocation: (() {
+      //TODO: improve this approach to get the initial location from the module manager
+      final appModule = moduleManager.findByName(AppModuleDefinition.moduleName);
+      if (appModule == null) {
+        // Fallback to root or a safe default if not found
+        return '/';
+      }
+      return appModule.initialLocation();
+    })(),
+    routes: moduleManager
+        .modules()
+        .expand((module) => module.getRouterConfig(ref).map((route) => route))
+        .toList(),
+    errorBuilder: (context, state) => PageNotFound(errorMessage: state.error.toString()),
+  );
+}

--- a/lib/navigation/app_navigation_provider.g.dart
+++ b/lib/navigation/app_navigation_provider.g.dart
@@ -1,0 +1,86 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'app_navigation_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(appRouter)
+const appRouterProvider = AppRouterFamily._();
+
+final class AppRouterProvider extends $FunctionalProvider<GoRouter, GoRouter, GoRouter>
+    with $Provider<GoRouter> {
+  const AppRouterProvider._({
+    required AppRouterFamily super.from,
+    required ModuleManager super.argument,
+  }) : super(
+         retry: null,
+         name: r'appRouterProvider',
+         isAutoDispose: true,
+         dependencies: null,
+         $allTransitiveDependencies: null,
+       );
+
+  @override
+  String debugGetCreateSourceHash() => _$appRouterHash();
+
+  @override
+  String toString() {
+    return r'appRouterProvider'
+        ''
+        '($argument)';
+  }
+
+  @$internal
+  @override
+  $ProviderElement<GoRouter> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  GoRouter create(Ref ref) {
+    final argument = this.argument as ModuleManager;
+    return appRouter(ref, argument);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(GoRouter value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<GoRouter>(value),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is AppRouterProvider && other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
+  }
+}
+
+String _$appRouterHash() => r'080a5c5ed449e4aac6e3510ac175de68dbeca995';
+
+final class AppRouterFamily extends $Family
+    with $FunctionalFamilyOverride<GoRouter, ModuleManager> {
+  const AppRouterFamily._()
+    : super(
+        retry: null,
+        name: r'appRouterProvider',
+        dependencies: null,
+        $allTransitiveDependencies: null,
+        isAutoDispose: true,
+      );
+
+  AppRouterProvider call(ModuleManager moduleManager) =>
+      AppRouterProvider._(argument: moduleManager, from: this);
+
+  @override
+  String toString() => r'appRouterProvider';
+}

--- a/lib/navigation/app_routes.dart
+++ b/lib/navigation/app_routes.dart
@@ -1,4 +1,5 @@
 class AppRoutes {
-  static const String home = 'home';
-  static const String splash = 'splash';
+  static const String home = '/home';
+  static const String splash = '/splash';
+  static const String initialLocation = splash;
 }

--- a/packages/auth/lib/module_definition/auth_module_definition.dart
+++ b/packages/auth/lib/module_definition/auth_module_definition.dart
@@ -5,7 +5,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 import '../navigation/auth_navigation.dart';
 
 class AuthModuleDefinition extends Module<Ref> {
-  static String moduleName = 'AppModuleDefinition';
+  static String moduleName = 'AuthModuleDefinition';
   AuthModuleDefinition() : super(moduleName);
 
   @override


### PR DESCRIPTION
This pull request introduces a modular and provider-based approach to navigation in the app, leveraging Riverpod and GoRouter for improved routing configuration and management. The changes center around refactoring navigation to support dynamic route registration via modules, enhancing maintainability and extensibility.

### Navigation Refactor and Provider Integration

* Added a new `appRouter` Riverpod provider in `app_navigation_provider.dart`, which constructs a `GoRouter` using registered modules and sets up error handling for unknown routes. (`[lib/navigation/app_navigation_provider.dartR1-R20](diffhunk://#diff-3fb7f2378b8c6ca500a5b0d0931a839ee58a1816c7fe403e3ec7451695f9787bR1-R20)`)
* Generated provider code for `appRouterProvider`, enabling family-based routing configuration with module arguments. (`[lib/navigation/app_navigation_provider.g.dartR1-R86](diffhunk://#diff-85bea81e5ef01e4f78c0806d97fc849c23837553a2c584f86e1dcc0a617af62dR1-R86)`)
* Updated `main.dart` to use the new provider-based router setup, replacing direct instantiation of `GoRouter` and passing the `ModuleManager` to the provider. (`[[1]](diffhunk://#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608L6-R9)`, `[[2]](diffhunk://#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608R20-R33)`)

### Modular Routing Enhancements

* Refactored `AppModuleDefinition` to use a new `initialLocation()` method and retrieve routes via the provider, supporting dynamic route configuration. (`[[1]](diffhunk://#diff-984638cac25880b16403c9c47ed2cc92eb2ebf571c068dbf21f7d4d4a56ca1d6R6)`, `[[2]](diffhunk://#diff-984638cac25880b16403c9c47ed2cc92eb2ebf571c068dbf21f7d4d4a56ca1d6R22-R26)`)
* Added `initialLocation` constant to `AppRoutes` and updated route paths to use leading slashes for consistency with GoRouter. (`[lib/navigation/app_routes.dartL2-R4](diffhunk://#diff-9ef5841296ecb2f773491977f46a47c662bbe54776e8a885525578cbe3a7298cL2-R4)`)
* Corrected the module name in `AuthModuleDefinition` to ensure proper registration and lookup. (`[packages/auth/lib/module_definition/auth_module_definition.dartL8-R8](diffhunk://#diff-06568fb03e2370a404c2c428486c9940ba72217c78dd847e79ec2126f3debd4bL8-R8)`)