### PR TITLE
feat: [tt][GG-021] Route redirection and build_runner updates

### DIFF
--- a/lib/navigation/app_navigation_provider.dart
+++ b/lib/navigation/app_navigation_provider.dart
@@ -1,15 +1,45 @@
+import 'package:auth/data/data_source/auth_remote_data_sourece.dart';
+import 'package:auth/data/repository/auth_repository.dart';
+import 'package:auth/navigation/auth_routes.dart';
 import 'package:feature_commons/module_definition/module_manager.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:go_router/go_router.dart';
 
 import '../ui/error_pages/page_not_found.dart';
 import '../module_definition/app_module_definition.dart';
+import 'app_routes.dart';
 
 part 'app_navigation_provider.g.dart';
 
 @riverpod
 GoRouter appRouter(Ref ref, ModuleManager moduleManager) {
+  final AsyncValue<User?> authState = ref.watch(authStateProvider);
+  final FirebaseAuth firebaseAuth = ref.watch(firebaseAuthProvider);
   return GoRouter(
+    redirect: (context, state) {
+      if (authState is AsyncLoading<User?>) {
+        return AppRoutes.splash;
+      }
+      if (authState is AsyncError<User?>) {
+        return AppRoutes.firebaseError;
+      }
+      final authenticated = authState.value != null;
+      final authenticating =
+          (state.matchedLocation == AuthRoutes.signup) ||
+          (state.matchedLocation == AuthRoutes.resetPassword);
+
+      if (!authenticated) {
+        return authenticating ? null : AuthRoutes.signin;
+      }
+      if (firebaseAuth.currentUser?.emailVerified == false) {
+        return AuthRoutes.verifyEmail;
+      }
+      final verifyingEmail = (state.matchedLocation == AuthRoutes.verifyEmail);
+      final splashing = (state.matchedLocation == AppRoutes.splash);
+
+      return (authenticating || verifyingEmail || splashing) ? AppRoutes.home : null;
+    },
     debugLogDiagnostics: true,
     initialLocation: (() {
       //TODO: improve this approach to get the initial location from the module manager

--- a/lib/navigation/app_navigation_provider.g.dart
+++ b/lib/navigation/app_navigation_provider.g.dart
@@ -65,7 +65,7 @@ final class AppRouterProvider extends $FunctionalProvider<GoRouter, GoRouter, Go
   }
 }
 
-String _$appRouterHash() => r'080a5c5ed449e4aac6e3510ac175de68dbeca995';
+String _$appRouterHash() => r'9f1a3fe15aae054bc53880f92eb83247e9b2b5e8';
 
 final class AppRouterFamily extends $Family
     with $FunctionalFamilyOverride<GoRouter, ModuleManager> {

--- a/lib/navigation/app_routes.dart
+++ b/lib/navigation/app_routes.dart
@@ -1,5 +1,7 @@
 class AppRoutes {
   static const String home = '/home';
   static const String splash = '/splash';
+  static const String firebaseError = '/firebase-error';
+  static const String pageNotFound = '/page-not-found';
   static const String initialLocation = splash;
 }

--- a/packages/auth/lib/data/repository/auth_repository.dart
+++ b/packages/auth/lib/data/repository/auth_repository.dart
@@ -28,6 +28,6 @@ AuthRepository authRepository(Ref ref) {
 }
 
 @riverpod
-Stream<User?> currentUserStream(Ref ref) {
+Stream<User?> authState(Ref ref) {
   return ref.watch(firebaseAuthProvider).authStateChanges();
 }

--- a/packages/auth/lib/data/repository/auth_repository.g.dart
+++ b/packages/auth/lib/data/repository/auth_repository.g.dart
@@ -50,25 +50,25 @@ final class AuthRepositoryProvider
 
 String _$authRepositoryHash() => r'58aed3301224fc414115fbe4f1357dfc86cc3407';
 
-@ProviderFor(currentUserStream)
-const currentUserStreamProvider = CurrentUserStreamProvider._();
+@ProviderFor(authState)
+const authStateProvider = AuthStateProvider._();
 
-final class CurrentUserStreamProvider
+final class AuthStateProvider
     extends $FunctionalProvider<AsyncValue<User?>, User?, Stream<User?>>
     with $FutureModifier<User?>, $StreamProvider<User?> {
-  const CurrentUserStreamProvider._()
+  const AuthStateProvider._()
     : super(
         from: null,
         argument: null,
         retry: null,
-        name: r'currentUserStreamProvider',
+        name: r'authStateProvider',
         isAutoDispose: true,
         dependencies: null,
         $allTransitiveDependencies: null,
       );
 
   @override
-  String debugGetCreateSourceHash() => _$currentUserStreamHash();
+  String debugGetCreateSourceHash() => _$authStateHash();
 
   @$internal
   @override
@@ -77,8 +77,8 @@ final class CurrentUserStreamProvider
 
   @override
   Stream<User?> create(Ref ref) {
-    return currentUserStream(ref);
+    return authState(ref);
   }
 }
 
-String _$currentUserStreamHash() => r'f8115e0f24aa6c9abc43c61679fbf3c9cae792d5';
+String _$authStateHash() => r'afdf515e14d0bb725ca181867cf6d626a5d85246';


### PR DESCRIPTION
This pull request introduces authentication-aware navigation to the app by integrating user authentication state into the routing logic. The main changes involve updating providers and navigation to ensure users are redirected appropriately based on their authentication and email verification status, and improving error handling routes.

**Authentication integration and navigation logic:**

* Added authentication state checks and redirect logic to the `GoRouter` in `appRouter`, ensuring users are routed to sign-in, email verification, splash, or error pages based on their current authentication and email verification status (`lib/navigation/app_navigation_provider.dart`).
* Updated the authentication state provider from `currentUserStream` to `authState` for clarity and consistency, and refactored all related provider code (`packages/auth/lib/data/repository/auth_repository.dart`, `packages/auth/lib/data/repository/auth_repository.g.dart`). [[1]](diffhunk://#diff-07eff0318098f2a86d28d6bd7038030d0b794d10345d3639924314cd42baea54L31-R31) [[2]](diffhunk://#diff-5c9a2fa5a215f19b24147df5b9a71f4640f12ebd4f49d7c609862d6cb92123eaL53-R71) [[3]](diffhunk://#diff-5c9a2fa5a215f19b24147df5b9a71f4640f12ebd4f49d7c609862d6cb92123eaL80-R84)

**Routing enhancements:**

* Added new route constants for error handling and page not found to `AppRoutes` (`lib/navigation/app_routes.dart`).
* Updated the generated provider hash to reflect changes in the navigation provider (`lib/navigation/app_navigation_provider.g.dart`).