### PR TITLE
fix: [tt][GG-023] Update and fix auth routes

### DIFF
--- a/packages/auth/lib/navigation/auth_routes.dart
+++ b/packages/auth/lib/navigation/auth_routes.dart
@@ -1,8 +1,8 @@
 class AuthRoutes {
-  static const String signin = 'signin';
-  static const String signup = 'signup';
-  static const String resetPassword = 'resetPassword';
-  static const String verifyEmail = 'verifyEmail';
-  static const String changePassword = 'changePassword';
-  static const String firebaseError = 'firebaseError';
+  static const String signin = '/signin';
+  static const String signup = '/signup';
+  static const String resetPassword = '/resetPassword';
+  static const String verifyEmail = '/verifyEmail';
+  static const String changePassword = '/changePassword';
+  static const String firebaseError = '/firebaseError';
 }


### PR DESCRIPTION
This pull request updates the route constants in the `AuthRoutes` class to consistently use leading slashes, aligning them with standard route naming conventions.

* Routing consistency:
  * Updated all route constants in `AuthRoutes` (`signin`, `signup`, `resetPassword`, `verifyEmail`, `changePassword`, `firebaseError`) to include a leading slash, e.g., `'/signin'` instead of `'signin'`.