### PR TITLE
chore: [tt][GG-018] Update auth package version and changelog (#26)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,28 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 2025-09-22
+
+### Changes
+
+---
+
+Packages with breaking changes:
+
+ - There are no breaking changes in this release.
+
+Packages with other changes:
+
+ - [`auth` - `v0.0.2+1`](#auth---v0021)
+
+---
+
+#### `auth` - `v0.0.2+1`
+
+ - **FIX**: [tt][GG-018] Update and fix auth routes (#25).
+ - **FIX**: [tt][GG-023] Update and fix auth routes (#24).
+
+
 ## 2025-09-17
 
 ### Changes

--- a/packages/auth/CHANGELOG.md
+++ b/packages/auth/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.0.2+1
+
+ - **FIX**: [tt][GG-018] Update and fix auth routes (#25).
+ - **FIX**: [tt][GG-023] Update and fix auth routes (#24).
+
 ## 0.0.2
 
  - **FEAT**: [tt][GG-018] Enhance module definition and manager, update commit hooks for GG format (#18).

--- a/packages/auth/pubspec.yaml
+++ b/packages/auth/pubspec.yaml
@@ -1,6 +1,6 @@
 name: auth
 description: "A new Flutter package project."
-version: 0.0.2
+version: 0.0.2+1
 
 environment:
   sdk: ^3.8.1


### PR DESCRIPTION
This pull request updates the `auth` package to version `0.0.2+1` and documents recent fixes to authentication routes. There are no breaking changes in this release.

Versioning and documentation updates:

* Bumped the `auth` package version in `pubspec.yaml` to `0.0.2+1` to reflect the new release.
* Added a new entry to `CHANGELOG.md` for the overall project and the `auth` package, detailing fixes to authentication routes. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR6-R27) [[2]](diffhunk://#diff-92a53f0443c779166479596f524334a472306c9c670de4548a641b3a0b706734R1-R5)

Bug fixes:

* Documented two fixes to authentication routes in both changelog files: [tt][GG-018] and [tt][GG-023]. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR6-R27) [[2]](diffhunk://#diff-92a53f0443c779166479596f524334a472306c9c670de4548a641b3a0b706734R1-R5)