### PR TITLE
fix: [tt][GG-023] Update and fix auth routes (#24)

### DIFF
--- a/packages/auth/lib/navigation/auth_routes.dart
+++ b/packages/auth/lib/navigation/auth_routes.dart
@@ -1,8 +1,8 @@
 class AuthRoutes {
-  static const String signin = 'signin';
-  static const String signup = 'signup';
-  static const String resetPassword = 'resetPassword';
-  static const String verifyEmail = 'verifyEmail';
-  static const String changePassword = 'changePassword';
-  static const String firebaseError = 'firebaseError';
+  static const String signin = '/signin';
+  static const String signup = '/signup';
+  static const String resetPassword = '/resetPassword';
+  static const String verifyEmail = '/verifyEmail';
+  static const String changePassword = '/changePassword';
+  static const String firebaseError = '/firebaseError';
 }


### PR DESCRIPTION
This pull request updates the route constants in the `AuthRoutes` class to use leading slashes, which aligns with standard route naming conventions in Flutter and improves consistency across the codebase.

Routing improvements:

* Updated all route constants in `AuthRoutes` (e.g., `signin`, `signup`, etc.) to include a leading slash, changing them from `'signin'` to `'/signin'`, and similarly for the other routes.