### PR TITLE
chore: [ch][GG-037] Allow 'auth' and 'ds_system' branch names in work…

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -2,7 +2,7 @@
 
 # Validate branch name
 BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
-if [[ ! $BRANCH_NAME =~ ^(main|ft/|tt/|rf/|cr/|wr/|fx/|hf/|dc/|ts|ch/) ]]; then
+if [[ ! $BRANCH_NAME =~ ^(main|ft/|tt/|rf/|cr/|wr/|fx/|hf/|dc/|ts|ch|auth|ds_system) ]]; then
   echo "Invalid branch name: $BRANCH_NAME"
   exit 1
 fi

--- a/.github/workflows/convention_checks.yml
+++ b/.github/workflows/convention_checks.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Validate branch name
         run: |
           BRANCH_NAME="${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}"
-          if [[ ! $BRANCH_NAME =~ ^(main|ft/|tt/|rf/|cr|wr|fx|hf|dc|ts|ch/) ]]; then
+            if [[ ! $BRANCH_NAME =~ ^(main|ft/|tt/|rf/|cr|wr|fx|hf|dc|ts|ch|auth|ds_system) ]]; then
             echo "Invalid branch name: $BRANCH_NAME"
             exit 1
           fi


### PR DESCRIPTION
This pull request updates the branch name validation rules in both the pre-push git hook and the GitHub workflow to allow two additional branch prefixes: `auth` and `ds_system`. This ensures that branches following these new naming conventions will pass validation checks during development and CI/CD processes.

Branch name validation updates:

* [`.githooks/pre-push`](diffhunk://#diff-d98b367aa518731b4158dd028ca94d051dfe32fefe54c4affde19f591ebc5fb6L5-R5): Added `auth` and `ds_system` as valid branch prefixes in the branch name validation regex.
* [`.github/workflows/convention_checks.yml`](diffhunk://#diff-5935acea485a30b1b8cf79c2c0d7c8da836b98330edba021dad8537eb1b9bbeaL21-R21): Updated the branch name validation in the workflow to include `auth` and `ds_system` prefixes.…flow and pre-push hook